### PR TITLE
fix(client): handle the case where there is no response in error

### DIFF
--- a/src/client-adapter/axios-adapter.ts
+++ b/src/client-adapter/axios-adapter.ts
@@ -95,7 +95,7 @@ export class AxiosAdapter implements ClientAdapter<AxiosResponse> {
     const id = this.axios.interceptors.response.use(
       (response: AxiosResponse) => response,
       async (error: AxiosError) => {
-        if (error.response != null && error.response != undefined) {
+        if (error.response != null) {
           const request = this.asRequest(error.config)
           const response = this.asResponse(error.response)
 

--- a/src/server-adapter/openid-connect-adapter.ts
+++ b/src/server-adapter/openid-connect-adapter.ts
@@ -37,10 +37,19 @@ export async function openidConnectDiscovery<R> (
   client: ClientAdapter<R>,
   issuerUrl: string
 ): Promise<ServerConfiguration> {
-  const clientResponse = await client.request({
-    method: 'GET',
-    url: issuerUrl + '/.well-known/openid-configuration'
-  })
+  let clientResponse: R | null | undefined = null
+  try {
+    clientResponse = await client.request({
+      method: 'GET',
+      url: issuerUrl + '/.well-known/openid-configuration'
+    })
+  } catch (e) {
+    if (clientResponse === undefined) {
+      throw new Error('OpenId Connect Discovery endpoint return an empty response (hint: maybe a network error)')
+    }
+    throw e
+  }
+
   const response = client.asResponse(clientResponse)
   const openidConfiguration: OpenidConfiguration = response.data
   return {


### PR DESCRIPTION
When network is disconnected, axios rejects and there is no response in the `error` object.
In this case, `error.reponse` is `undefined` so `response.data` in `asResponse()` will throw an error because it's unable to access `data` of undefined.